### PR TITLE
common: actually check if the LCD is disabled

### DIFF
--- a/src/common/common.asm
+++ b/src/common/common.asm
@@ -6,7 +6,7 @@ SECTION "Common", ROMX, BANK[1]
 DisableLCD:
     ; If the LCDC is already disabled, return.
     ld a, [rLCDC]
-    and a, %00000001
+    and a, %10000000
     ret z
 .loop:
 


### PR DESCRIPTION
Bit 0 of LCDC determines if the BG/window display is enabled/disabled.
We want to check bit 7.